### PR TITLE
Fixing typo

### DIFF
--- a/proto2cpp.py
+++ b/proto2cpp.py
@@ -191,7 +191,7 @@ class proto2cpp:
   ## @param string String to be written to error log file.
   #
   def logError(self, string):
-    if self.logLevel >= self.logError:
+    if self.logLevel >= self.logErrors:
       with open(self.errorLogFile, 'a') as theFile:
         theFile.write(string)
 


### PR DESCRIPTION
Comparison was with method logError instead of variable self.logErrors